### PR TITLE
Iterators of results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microjson"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 license = "GPL-3.0-only"
 repository = "https://github.com/rspencer01/microjson"


### PR DESCRIPTION
Addresses #5 by replacing `unwrap`s with `Results` that are returned by the iterators.