### PR TITLE
Improve errors and interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microjson"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2018"
 license = "GPL-3.0-only"
 repository = "https://github.com/rspencer01/microjson"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The error would only be reported when you attempted to iterate to the fourth ite
 If you need to know that the data is sound, use [`JSONValue::verify`].  Alternatively, you can parse and verify in one step.
 ```rust
 # use microjson::JSONValue;
-let value = JSONValue::parse_and_verify(r#" [1,2,3,5"foo"] "#);
+let value = JSONValue::load_and_verify(r#" [1,2,3,5"foo"] "#);
 ```
 
 Features

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ You can read strings and integers easily:
 ```rust
 # use microjson::{JSONValue, JSONParsingError};
 # fn main() -> Result<(), JSONParsingError> {
-let integer = JSONValue::parse("42")?;
+let integer = JSONValue::load("42");
 
 let value : isize = integer.read_integer()?;
 
-let string = JSONValue::parse("\"hello there\"")?;
+let string = JSONValue::load("\"hello there\"");
 
 let value : &str = string.read_string()?;
 # Ok(())
@@ -42,7 +42,7 @@ You can read arrays like this:
 # fn main() -> Result<(), JSONParsingError> {
 let input = r#" [0, 1, 2, 3, 4, 5] "#;
 
-let array = JSONValue::parse(input)?;
+let array = JSONValue::load(input);
 
 for (n, item) in array.iter_array()?.enumerate() {
     let value = item.read_integer()?;
@@ -58,7 +58,7 @@ And, of course, any combination of the above:
 # fn main() -> Result<(), JSONParsingError> {
 let input = r#" { "arr": [3, "foo", 3.625, false] } "#;
 
-let object = JSONValue::parse(input)?;
+let object = JSONValue::load(input);
 
 assert_eq!(
     object.get_key_value("arr")?.iter_array()?.nth(2).unwrap().read_float()?,
@@ -74,7 +74,7 @@ If you are unsure what kind of data you have, you can query the [`JSONValueType`
 # fn main() -> Result<(), JSONParsingError> {
 let input = r#" 3.1415 "#;
 
-let object = JSONValue::parse(input)?;
+let object = JSONValue::load(input);
 
 match object.value_type {
     JSONValueType::String => {},
@@ -83,6 +83,7 @@ match object.value_type {
     JSONValueType::Array => {},
     JSONValueType::Bool => {},
     JSONValueType::Null => {},
+    JSONValueType::Error => {},
 }
 # Ok(())
 # }
@@ -94,7 +95,7 @@ Verifying Data
 To load some JSON, you need only call
 ```rust
 # use microjson::JSONValue;
-let value = JSONValue::parse(r#" [1,2,3,5"foo"] "#);
+let value = JSONValue::load(r#" [1,2,3,5"foo"] "#);
 ```
 However, this data is malformed.  [`JSONValue::parse`] will return an `Ok` result, as to determine that the data was corrupt would require scanning through the entire string.
 The error would only be reported when you attempted to iterate to the fourth item and parse it as a value.

--- a/benches/criterion_bench.rs
+++ b/benches/criterion_bench.rs
@@ -9,7 +9,9 @@ pub fn massive_random(c: &mut Criterion) {
     path.push("resources/test/massive_random.json");
     let json_payload = read_to_string(&path).unwrap();
 
-    c.bench_function("load", |b| b.iter(|| JSONValue::parse_and_verify(&json_payload)));
+    c.bench_function("load", |b| {
+        b.iter(|| JSONValue::parse_and_verify(&json_payload))
+    });
 
     let value = JSONValue::parse(&json_payload);
     c.bench_function("single_retrieve", |b| {
@@ -37,7 +39,9 @@ pub fn large_array(c: &mut Criterion) {
     path.push("resources/test/list_of_squares.json");
     let json_payload = read_to_string(&path).unwrap();
 
-    c.bench_function("load_array", |b| b.iter(|| JSONValue::parse_and_verify(&json_payload)));
+    c.bench_function("load_array", |b| {
+        b.iter(|| JSONValue::parse_and_verify(&json_payload))
+    });
 
     let json = JSONValue::parse(&json_payload).unwrap();
     c.bench_function("read_array_sequentially", |b| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,3 +52,25 @@ impl core::fmt::Display for JSONParsingError {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate std;
+    use std::string::ToString;
+
+    #[test]
+    fn error_formatting() {
+        // This is mostly to check the formatting doesn't crash or overlap, rather than the format exactly
+        let mut messages = std::collections::HashSet::new();
+        messages.insert(JSONParsingError::CannotParseArray.to_string());
+        messages.insert(JSONParsingError::CannotParseFloat.to_string());
+        messages.insert(JSONParsingError::CannotParseInteger.to_string());
+        messages.insert(JSONParsingError::CannotParseObject.to_string());
+        messages.insert(JSONParsingError::CannotParseString.to_string());
+        messages.insert(JSONParsingError::KeyNotFound.to_string());
+        messages.insert(JSONParsingError::UnexpectedToken.to_string());
+        messages.insert(JSONParsingError::EndOfStream.to_string());
+        assert_eq!(messages.len(), 8);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,54 @@
+/// Errors while parsing JSON
+///
+/// Due to the "scan once" philosophy of this crate, errors can either be returned when first
+/// constructing a [`JSONValue`] or when trying to read it using one of the accessors.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum JSONParsingError {
+    /// Attempt to parse an object that is not an array as an array
+    CannotParseArray,
+    /// Attempt to parse an object that is not a float as a float
+    CannotParseFloat,
+    /// Attempt to parse an object that is not an integer as an integer
+    CannotParseInteger,
+    /// Attempt to parse an object that is not an object as an object
+    CannotParseObject,
+    /// Attempt to parse an object that is not a string as an string
+    CannotParseString,
+    /// The key is not present in the object
+    KeyNotFound,
+    /// There was an unexpected token in the input stream
+    UnexpectedToken,
+    /// The input stream terminated while scanning a type
+    EndOfStream,
+}
+
+impl core::fmt::Debug for JSONParsingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::KeyNotFound => {
+                write!(f, "key not found")
+            }
+            Self::EndOfStream => {
+                write!(f, "stream ended while parsing JSON")
+            }
+            Self::UnexpectedToken => {
+                write!(f, "unexpected token")
+            }
+            Self::CannotParseArray => {
+                write!(f, "error parsing array")
+            }
+            Self::CannotParseFloat => {
+                write!(f, "error parsing float")
+            }
+            Self::CannotParseInteger => {
+                write!(f, "error parsing integer")
+            }
+            Self::CannotParseString => {
+                write!(f, "error parsing string")
+            }
+            Self::CannotParseObject => {
+                write!(f, "error parsing object")
+            }
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 ///
 /// Due to the "scan once" philosophy of this crate, errors can either be returned when first
 /// constructing a [`JSONValue`] or when trying to read it using one of the accessors.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum JSONParsingError {
     /// Attempt to parse an object that is not an array as an array
     CannotParseArray,
@@ -22,7 +22,7 @@ pub enum JSONParsingError {
     EndOfStream,
 }
 
-impl core::fmt::Debug for JSONParsingError {
+impl core::fmt::Display for JSONParsingError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::KeyNotFound => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,12 @@ pub enum JSONParsingError {
     UnexpectedToken,
     /// The input stream terminated while scanning a type
     EndOfStream,
+    /// Escape sequence too short (all escape sequences must be four hex digits long)
+    TooShortEscapeSequence,
+    /// Escape sequence doesn't map to a character
+    InvalidUnicodeEscapeSequence,
+    /// Escape pattern (\x) doesn't make sense
+    InvalidEscapeSequence(char),
 }
 
 impl core::fmt::Display for JSONParsingError {
@@ -49,6 +55,15 @@ impl core::fmt::Display for JSONParsingError {
             Self::CannotParseObject => {
                 write!(f, "error parsing object")
             }
+            Self::TooShortEscapeSequence => {
+                write!(f, "escape sequence fewer than four digits")
+            }
+            Self::InvalidUnicodeEscapeSequence => {
+                write!(f, "escape sequence doesn't map to a character")
+            }
+            Self::InvalidEscapeSequence(x) => {
+                write!(f, "invalid escape sequence \"\\{}\"", x)
+            }
         }
     }
 }
@@ -71,6 +86,10 @@ mod test {
         messages.insert(JSONParsingError::KeyNotFound.to_string());
         messages.insert(JSONParsingError::UnexpectedToken.to_string());
         messages.insert(JSONParsingError::EndOfStream.to_string());
-        assert_eq!(messages.len(), 8);
+        messages.insert(JSONParsingError::TooShortEscapeSequence.to_string());
+        messages.insert(JSONParsingError::InvalidUnicodeEscapeSequence.to_string());
+        messages.insert(JSONParsingError::InvalidEscapeSequence('q').to_string());
+        messages.insert(JSONParsingError::InvalidEscapeSequence('v').to_string());
+        assert_eq!(messages.len(), 12);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,60 +17,8 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
-/// Errors while parsing JSON
-///
-/// Due to the "scan once" philosophy of this crate, errors can either be returned when first
-/// constructing a [`JSONValue`] or when trying to read it using one of the accessors.
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum JSONParsingError {
-    /// Attempt to parse an object that is not an array as an array
-    CannotParseArray,
-    /// Attempt to parse an object that is not a float as a float
-    CannotParseFloat,
-    /// Attempt to parse an object that is not an integer as an integer
-    CannotParseInteger,
-    /// Attempt to parse an object that is not an object as an object
-    CannotParseObject,
-    /// Attempt to parse an object that is not a string as an string
-    CannotParseString,
-    /// The key is not present in the object
-    KeyNotFound,
-    /// There was an unexpected token in the input stream
-    UnexpectedToken,
-    /// The input stream terminated while scanning a type
-    EndOfStream,
-}
-
-impl core::fmt::Debug for JSONParsingError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match *self {
-            Self::KeyNotFound => {
-                write!(f, "Key not found")
-            }
-            Self::EndOfStream => {
-                write!(f, "Stream ended while parsing JSON")
-            }
-            Self::UnexpectedToken => {
-                write!(f, "Unexpected token")
-            }
-            Self::CannotParseArray => {
-                write!(f, "Error parsing array")
-            }
-            Self::CannotParseFloat => {
-                write!(f, "Error parsing float")
-            }
-            Self::CannotParseInteger => {
-                write!(f, "Error parsing integer")
-            }
-            Self::CannotParseString => {
-                write!(f, "Error parsing string")
-            }
-            Self::CannotParseObject => {
-                write!(f, "Error parsing object")
-            }
-        }
-    }
-}
+mod error;
+pub use error::JSONParsingError;
 
 /// Denotes the different types of values JSON objects can have
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,14 @@ fn trim_start(value: &str) -> (&str, usize) {
 }
 
 impl<'a> JSONValue<'a> {
+    /// Create a new `JSONValue` from an input string
+    ///
+    /// This is the primary method of constructing a [`JSONValue`]. It cannot fail, although the
+    /// value might have type [`JSONValueType::Error`]. However, a malformed payload may have a
+    /// type that is not `JSONValueType::Error`.
+    ///
+    /// If you want to load the payload and verify that it is valid JSON, use
+    /// [`JSONValue::load_and_verify`].
     pub fn load(contents: &'a str) -> JSONValue {
         let (contents, _) = trim_start(contents);
         let value_type = JSONValue::peek_value_type(contents);
@@ -88,7 +96,7 @@ impl<'a> JSONValue<'a> {
     /// Confirm that this [`JSONValue`] is proper JSON
     ///
     /// This will scan through the entire JSON and confirm that it is properly formatted.
-    /// See also [`JSONValue::parse_and_verify`].
+    /// See also [`JSONValue::load_and_verify`].
     ///
     /// ## Example
     /// ```
@@ -104,7 +112,10 @@ impl<'a> JSONValue<'a> {
         Ok(())
     }
 
-    pub fn parse_and_verify(contents: &'a str) -> Result<JSONValue, JSONParsingError> {
+    /// Load a JSON value from a payload and verify that it is valid JSON.
+    ///
+    /// This is equivalent to calling [`JSONValue::load`] followed by [`JSONValue::verify`].
+    pub fn load_and_verify(contents: &'a str) -> Result<JSONValue, JSONParsingError> {
         let value = JSONValue::load(contents);
         value.verify()?;
         Ok(value)
@@ -665,9 +676,9 @@ mod test {
 
     #[test]
     fn verifying() {
-        assert!(JSONValue::parse_and_verify(" 123 ").is_ok());
-        assert!(JSONValue::parse_and_verify("[123]").is_ok());
-        assert!(JSONValue::parse_and_verify("\"foo\"").is_ok());
+        assert!(JSONValue::load_and_verify(" 123 ").is_ok());
+        assert!(JSONValue::load_and_verify("[123]").is_ok());
+        assert!(JSONValue::load_and_verify("\"foo\"").is_ok());
     }
 
     #[test]

--- a/tests/large_input.rs
+++ b/tests/large_input.rs
@@ -2,7 +2,7 @@ use microjson::*;
 
 #[test]
 fn large_input_read() {
-    let value = JSONValue::parse(JSON_PAYLOAD).unwrap();
+    let value = JSONValue::load(JSON_PAYLOAD);
     assert_eq!(
         value
             .iter_array()


### PR DESCRIPTION
The function `parse` implied it did much more than what was actually happening. In fact, it was only checking the first character of the payload to guess the type of the string. The name `load` is closer to what it actually does.

It is now possible to `load` a JSON which obviously is nonconformant (i.e. its first character is wrong). These have a type JSONValueType::Error.